### PR TITLE
Fix MSLD parser to ignore case of keys

### DIFF
--- a/src/main/java/it/sauronsoftware/ftp4j/listparsers/MLSDListParser.java
+++ b/src/main/java/it/sauronsoftware/ftp4j/listparsers/MLSDListParser.java
@@ -112,7 +112,7 @@ public class MLSDListParser implements FTPListParser {
 			if (sep == -1) {
 				throw new FTPListParseException();
 			}
-			String key = aux.substring(0, sep).trim();
+			String key = aux.substring(0, sep).trim().toLowerCase();
 			String value = aux.substring(sep + 1, aux.length()).trim();
 			if (key.length() == 0 || value.length() == 0) {
 				throw new FTPListParseException();


### PR DESCRIPTION
Some MSLD implementation return keys with mixed cases. This PR just puts all the keys in lowercase.